### PR TITLE
GEN-10: Implement feature to display news articles in HTML format

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
+from fastapi.responses import HTMLResponse
+from jinja2 import Template
 from gnews_api import fetch_news
 
 app = FastAPI()
@@ -7,7 +9,9 @@ app = FastAPI()
 def read_root():
     return {'message': 'Welcome to our news application!'}
 
-@app.get('/news')
+@app.get('/news', response_class=HTMLResponse)
 def get_news():
     news = fetch_news('gen ai')
-    return news
+    with open('templates/news.html') as file_:
+        template = Template(file_.read())
+    return template.render(articles=news)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi==0.68.1
 uvicorn==0.15.0
 requests==2.26.0
 python-dotenv==0.19.1
+jinja2==3.0.3

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gen AI News</title>
+</head>
+<body>
+    <h1>Gen AI News</h1>
+    {% for article in articles %}
+    <div>
+        <h2><a href="{{ article.url }}">{{ article.title }}</a></h2>
+        <p>{{ article.description }}</p>
+        <p>Published at: {{ article.publishedAt }}</p>
+        <p>Source: <a href="{{ article.source.url }}">{{ article.source.name }}</a></p>
+    </div>
+    {% endfor %}
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,11 @@ def test_read_root():
 
 @patch('main.fetch_news')
 def test_get_news(mock_fetch):
-    mock_fetch.return_value = {'articles': [{'title': 'Test Article'}]}
+    mock_fetch.return_value = [{'title': 'Test Article', 'description': 'Test Description', 'publishedAt': '2022-01-01', 'source': {'name': 'Test Source', 'url': 'https://test.com'}, 'url': 'https://test.com/article'}]
     response = test_app.get('/news')
     assert response.status_code == 200
-    assert response.json() == {'articles': [{'title': 'Test Article'}]}
+    assert 'Test Article' in response.text
+    assert 'Test Description' in response.text
+    assert '2022-01-01' in response.text
+    assert 'Test Source' in response.text
+    assert 'https://test.com' in response.text


### PR DESCRIPTION
This PR implements a feature to display the news articles fetched from the GNews API in a user-friendly HTML format. A new route has been added to the FastAPI application that returns the articles in an HTML response. The HTML template for the articles has been added, and the `jinja2` library is used to render the template with the articles data.

### Test Plan

pytest